### PR TITLE
Remove .composer directory from Path to autoload file.

### DIFF
--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -18,7 +18,7 @@ We recommend installing the [PhpcrBrowser](https://github.com/symfony-cmf/phpcrb
 The shortest self-contained example should output a line with 'value':
 
     <?php
-    require("/path/to/jackalope-jackrabbit/vendor/.composer/autoload.php");
+    require("/path/to/jackalope-jackrabbit/vendor/autoload.php");
 
     $factoryclass = '\Jackalope\RepositoryFactoryJackrabbit';
     $parameters = array('jackalope.jackrabbit_uri' => 'http://localhost:8080/server');


### PR DESCRIPTION
Using the jackalope-jackrabbit/vendor/.composer/autoload.php file gave me a deprecation error and forwarded me to jackalope-jackrabbit/vendor/autoload.php
