### PR TITLE
Removed capitalisation of -t option in "Listing node contents" example

### DIFF
--- a/phpcr-shell/interacting.rst
+++ b/phpcr-shell/interacting.rst
@@ -98,7 +98,7 @@ node properties and children which are defined in the schema with the ``-t`` opt
     | jcr:primaryType    | NAME                    | slinpTest:article                              |
     | title              | STRING                  | Slinp Web Content Framework                    |
     +--------------------+-------------------------+------------------------------------------------+
-    PHPCRSH> ls -T
+    PHPCRSH> ls -t
     /cms/foo [nt:unstructured] > nt:base
     +--------------------+-------------------------+------------------------------------------------+
     | home               | slinpTest:article       | Home                                           |


### PR DESCRIPTION
A capital -T returns: `[RuntimeException] The "-T" option does not exist.`